### PR TITLE
Fix email template link and revalidation path

### DIFF
--- a/src/app/api/deal/route.ts
+++ b/src/app/api/deal/route.ts
@@ -100,7 +100,7 @@ export async function POST(req: Request) {
               <p>თქვენთვის შეიქმნა გარიგება პლატფორმა Shuamavali.ge-ზე.</p>
               <p>
                 დეტალების სანახავად ეწვიეთ შემდეგ ბმულს:
-                <a href="${process.env.BASE_URL}/app/deal/${newDeal.id} style="color: #4A90E2;">იხილეთ გარიგება</a>
+                <a href="${process.env.BASE_URL}/app/deal/${newDeal.id}" style="color: #4A90E2;">იხილეთ გარიგება</a>
               </p>
               <hr />
               <small>ეს წერილი გამოგზავნილია ავტომატურად. გთხოვთ, არ უპასუხოთ.</small>

--- a/src/lib/actions/deal.ts
+++ b/src/lib/actions/deal.ts
@@ -15,7 +15,9 @@ async function updateStatus(
       data: { status },
     });
 
-    revalidatePath(`/deals/${dealId}`);
+    // Revalidate the actual deal page after status update
+    // The route lives under /app/deal/[dealId]
+    revalidatePath(`/app/deal/${dealId}`);
     return { success: successMsg };
   } catch (error) {
     console.error(`${status} შეცდომა:`, error);


### PR DESCRIPTION
## Summary
- fix hyperlink quoting in deal invite email
- correct revalidate path for deal status updates

## Testing
- `npm install` *(fails: 403 Forbidden while fetching prisma binaries)*

------
https://chatgpt.com/codex/tasks/task_b_6878cfac5f08832c958fdbd65ebd957b